### PR TITLE
Fixes #1: Settings don't persist

### DIFF
--- a/TrafficSimulationAdjuster/Options.cs
+++ b/TrafficSimulationAdjuster/Options.cs
@@ -10,7 +10,6 @@ public class TrafficSimulationAdjusterOptions : ModSetting
     public TrafficSimulationAdjusterOptions(IMod mod)
         : base(mod)
     {
-        SetDefaults();
     }
 
     private int _trafficReductionCoefficient;


### PR DESCRIPTION
Fixes #1: setDefaults is called automatically by ModSettings on init. You don't need to call it directly.